### PR TITLE
Use APP_REFERENCE if already set

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -8,7 +8,9 @@ BUILD_DIR=$1
 CACHE_DIR=$2
 ENV_DIR=$3
 
-APP_REFERENCE=$(cat ${ENV_DIR}/APP_REFERENCE)
+if [[ -z "${APP_REFERENCE}" ]]; then
+    APP_REFERENCE=$(cat ${ENV_DIR}/APP_REFERENCE)
+fi
 
 if [[ -z "${APP_REFERENCE}" ]]; then
     echo "APP_REFERENCE was not set. Aborting" | indent


### PR DESCRIPTION
With the adoption of `envkey-heroku-buildpack`, environment variables are set in the build environment rather than the environment directory, as is typical during the compile phase.  This change allows `APP_REFERENCE` to be inherited from the build environment while maintaining historical compatibility.